### PR TITLE
Add ResultExt::from_err() wrt #119

### DIFF
--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -310,6 +310,11 @@ macro_rules! error_chain_processed {
             fn chain_err<F, EK>(self, callback: F) -> ::std::result::Result<T, $error_name>
                 where F: FnOnce() -> EK,
                       EK: Into<$error_kind_name>;
+            /// Converts a convertible error via `From::from` to
+            /// the result error. Useful to turn e.g. `std::io::Error`
+            /// into our own Error type.
+            fn from_err(self) -> ::std::result::Result<T, $error_name>
+                where $error_name: ::std::convert::From<E>;
         }
 
         impl<T, E> $result_ext_name<T, E> for ::std::result::Result<T, E> where E: ::std::error::Error + Send + 'static {
@@ -321,6 +326,10 @@ macro_rules! error_chain_processed {
                     $crate::ChainedError::new(callback().into(), state)
                 })
             }
+            fn from_err(self) -> ::std::result::Result<T, $error_name>
+                where $error_name: ::std::convert::From<E> {
+                    return self.map_err(From::from);
+                }
         }
 
 


### PR DESCRIPTION
Is that ok? The macros are so complex I don't really know. But it compiles and works in my own project as expected. Also, didn't add any tests.