### PR TITLE
added hidden nonexaustive variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [Allow `chain_err` to be used on `Option<T>`](https://github.com/rust-lang-nursery/error-chain/pull/156)
 - [Add support for creating an error chain on boxed trait errors (`Box<Error>`)](https://github.com/rust-lang-nursery/error-chain/pull/156)
 - [Remove lint for unused doc comment.](https://github.com/rust-lang-nursery/error-chain/pull/199)
+- [Make generated `ErrorKind` enums non-exhaustive](https://github.com/rust-lang-nursery/error-chain/pull/193)
 
 # 0.10.0
 
@@ -20,7 +21,7 @@
 
 # 0.8.1
 
-- Add crates.io categorie.
+- Add crates.io category.
 
 # 0.8.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,6 +349,7 @@
 //! match Error::from("error!") {
 //!     Error(ErrorKind::InvalidToolchainName(_), _) => { }
 //!     Error(ErrorKind::Msg(_), _) => { }
+//!     _ => { }
 //! }
 //! # }
 //! ```

--- a/src/quick_error.rs
+++ b/src/quick_error.rs
@@ -200,6 +200,9 @@ macro_rules! quick_error {
                 $(#[$imeta])*
                 $iitem $(($( $ttyp ),*))* $({$( $svar: $styp ),*})*,
             )*
+
+            #[doc(hidden)]
+            __Nonexhaustive {}
         }
     };
     // Private enum (Queue Empty)
@@ -278,6 +281,8 @@ macro_rules! quick_error {
                             display_fn(self, fmt)
                         }
                     )*
+
+                    _ => Ok(())
                 }
             }
         }
@@ -325,6 +330,8 @@ macro_rules! quick_error {
                                 {$( $funcs )*})
                         }
                     )*
+
+                    _ => "",
                 }
             }
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -491,7 +491,8 @@ fn error_patterns() {
 
     // Tuples look nice when matching errors
     match Error::from("Test") {
-        Error(ErrorKind::Msg(_), _) => {}
+        Error(ErrorKind::Msg(_), _) => {},
+        _ => {},
     }
 }
 


### PR DESCRIPTION
fixes #182 

i first tried to add the variant inside `error_chain_processed!`, but that failed with a weird macro error: 
```
error: attempted to repeat an expression containing no syntax variables matched as repeating at this depth
  --> src\quick_error.rs:98:20
   |
98 |             enum [$( $(#[$emeta])* => $eitem $(( $($etyp),* ))* )*
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

so i had to drop down to `quick_error` and impl'd it there. seems to work ok.