### PR TITLE
fixed broken links after move to rust-lang-nursery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,22 @@
 # 0.11.0-rc.2
 
-- [Make `ErrorChainIter`'s field private](https://github.com/brson/error-chain/issues/178)
-- [Rename `ErrorChainIter` to `Iter`](https://github.com/brson/error-chain/issues/168)
-- [Implement `Debug` for `ErrorChainIter`](https://github.com/brson/error-chain/issues/169)
-- [Rename `ChainedError::display` to `display_chain`](https://github.com/brson/error-chain/issues/180)
-- [Add a new method for `Error`: `chain_err`.](https://github.com/brson/error-chain/pull/141)
-- [Allow `chain_err` to be used on `Option<T>`](https://github.com/brson/error-chain/pull/156)
-- [Add support for creating an error chain on boxed trait errors (`Box<Error>`)](https://github.com/brson/error-chain/pull/156)
-- [Remove lint for unused doc comment.](https://github.com/brson/error-chain/pull/199)
+- [Make `ErrorChainIter`'s field private](https://github.com/rust-lang-nursery/error-chain/issues/178)
+- [Rename `ErrorChainIter` to `Iter`](https://github.com/rust-lang-nursery/error-chain/issues/168)
+- [Implement `Debug` for `ErrorChainIter`](https://github.com/rust-lang-nursery/error-chain/issues/169)
+- [Rename `ChainedError::display` to `display_chain`](https://github.com/rust-lang-nursery/error-chain/issues/180)
+- [Add a new method for `Error`: `chain_err`.](https://github.com/rust-lang-nursery/error-chain/pull/141)
+- [Allow `chain_err` to be used on `Option<T>`](https://github.com/rust-lang-nursery/error-chain/pull/156)
+- [Add support for creating an error chain on boxed trait errors (`Box<Error>`)](https://github.com/rust-lang-nursery/error-chain/pull/156)
+- [Remove lint for unused doc comment.](https://github.com/rust-lang-nursery/error-chain/pull/199)
 
 # 0.10.0
 
-- [Add a new constructor for `Error`: `with_chain`.](https://github.com/brson/error-chain/pull/126)
-- [Add the `ensure!` macro.](https://github.com/brson/error-chain/pull/135)
+- [Add a new constructor for `Error`: `with_chain`.](https://github.com/rust-lang-nursery/error-chain/pull/126)
+- [Add the `ensure!` macro.](https://github.com/rust-lang-nursery/error-chain/pull/135)
 
 # 0.9.0
 
-- Revert [Add a `Sync` bound to errors](https://github.com/brson/error-chain/pull/110)
+- Revert [Add a `Sync` bound to errors](https://github.com/rust-lang-nursery/error-chain/pull/110)
 
 # 0.8.1
 
@@ -24,8 +24,8 @@
 
 # 0.8.0
 
-- [Add a `Sync` bound to errors](https://github.com/brson/error-chain/pull/110)
-- [Add `ChainedError::display` to format error chains](https://github.com/brson/error-chain/pull/113)
+- [Add a `Sync` bound to errors](https://github.com/rust-lang-nursery/error-chain/pull/110)
+- [Add `ChainedError::display` to format error chains](https://github.com/rust-lang-nursery/error-chain/pull/113)
 
 # 0.7.2
 
@@ -35,11 +35,11 @@
 
 # 0.7.1
 
-- [Add the `bail!` macro](https://github.com/brson/error-chain/pull/76)
+- [Add the `bail!` macro](https://github.com/rust-lang-nursery/error-chain/pull/76)
 
 # 0.7.0
 
-- [Rollback several design changes to fix regressions](https://github.com/brson/error-chain/pull/75)
+- [Rollback several design changes to fix regressions](https://github.com/rust-lang-nursery/error-chain/pull/75)
 - New `Variant(Error) #[attrs]` for `links` and `foreign_links`.
 - Hide implementation details from the doc.
 - Always generate `Error::backtrace`.
@@ -69,41 +69,41 @@
 
 # 0.5.0
 
-- [Only generate backtraces with RUST_BACKTRACE set](https://github.com/brson/error-chain/pull/27)
-- [Fixup matching, disallow repeating "types" section](https://github.com/brson/error-chain/pull/26)
-- [Fix tests on stable/beta](https://github.com/brson/error-chain/pull/28)
-- [Only deploy docs when tagged](https://github.com/brson/error-chain/pull/30)
+- [Only generate backtraces with RUST_BACKTRACE set](https://github.com/rust-lang-nursery/error-chain/pull/27)
+- [Fixup matching, disallow repeating "types" section](https://github.com/rust-lang-nursery/error-chain/pull/26)
+- [Fix tests on stable/beta](https://github.com/rust-lang-nursery/error-chain/pull/28)
+- [Only deploy docs when tagged](https://github.com/rust-lang-nursery/error-chain/pull/30)
 
 Contributors: benaryorg, Brian Anderson, Georg Brandl
 
 # 0.4.2
 
-- [Fix the resolution of the ErrorKind description method](https://github.com/brson/error-chain/pull/24)
+- [Fix the resolution of the ErrorKind description method](https://github.com/rust-lang-nursery/error-chain/pull/24)
 
 Contributors: Brian Anderson
 
 # 0.4.1 (yanked)
 
-- [Fix a problem with resolving methods of the standard Error type](https://github.com/brson/error-chain/pull/22)
+- [Fix a problem with resolving methods of the standard Error type](https://github.com/rust-lang-nursery/error-chain/pull/22)
 
 Contributors: Brian Anderson
 
 # 0.4.0 (yanked)
 
-- [Remove the foreign link description and forward to the foreign error](https://github.com/brson/error-chain/pull/19)
-- [Allow missing sections](https://github.com/brson/error-chain/pull/17)
+- [Remove the foreign link description and forward to the foreign error](https://github.com/rust-lang-nursery/error-chain/pull/19)
+- [Allow missing sections](https://github.com/rust-lang-nursery/error-chain/pull/17)
 
 Contributors: Brian Anderson, Taylor Cramer
 
 # 0.3.0
 
-- [Forward Display implementation for foreign errors](https://github.com/brson/error-chain/pull/13)
+- [Forward Display implementation for foreign errors](https://github.com/rust-lang-nursery/error-chain/pull/13)
 
 Contributors: Brian Anderson, Taylor Cramer
 
 # 0.2.2
 
-- [Don't require `types` section in macro invocation](https://github.com/brson/error-chain/pull/8)
-- [Add "quick start" to README](https://github.com/brson/error-chain/pull/9)
+- [Don't require `types` section in macro invocation](https://github.com/rust-lang-nursery/error-chain/pull/8)
+- [Add "quick start" to README](https://github.com/rust-lang-nursery/error-chain/pull/9)
 
 Contributors: Brian Anderson, Jake Shadle, Nate Mara

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ keywords = ["error"]
 categories = ["rust-patterns"]
 
 documentation = "https://docs.rs/error-chain"
-repository = "https://github.com/brson/error-chain"
+repository = "https://github.com/rust-lang-nursery/error-chain"
 readme = "README.md"
 
 license = "MIT/Apache-2.0"
 
 [badges]
-travis-ci = { repository = "brson/error-chain" }
+travis-ci = { repository = "rust-lang-nursery/error-chain" }
 
 [features]
 default = ["backtrace", "example_generated"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # error-chain - Consistent error handling for Rust
 
-[![Build Status](https://api.travis-ci.org/brson/error-chain.svg?branch=master)](https://travis-ci.org/brson/error-chain)
+[![Build Status](https://api.travis-ci.org/rust-lang-nursery/error-chain.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/error-chain)
 [![Latest Version](https://img.shields.io/crates/v/error-chain.svg)](https://crates.io/crates/error-chain)
-[![License](https://img.shields.io/github/license/brson/error-chain.svg)](https://github.com/brson/error-chain)
+[![License](https://img.shields.io/github/license/rust-lang-nursery/error-chain.svg)](https://github.com/rust-lang-nursery/error-chain)
 
 `error-chain` makes it easy to take full advantage of Rust's error
 handling features without the overhead of maintaining boilerplate
@@ -20,7 +20,7 @@ If you just want to set up your new project with error-chain,
 follow the [quickstart.rs] template, and read this [intro]
 to error-chain.
 
-[quickstart.rs]: https://github.com/brson/error-chain/blob/master/examples/quickstart.rs
+[quickstart.rs]: https://github.com/rust-lang-nursery/error-chain/blob/master/examples/quickstart.rs
 [intro]: http://brson.github.io/2016/11/30/starting-with-error-chain
 
 ## Supported Rust version

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! follow the [quickstart.rs] template, and read this [intro]
 //! to error-chain.
 //!
-//! [quickstart.rs]: https://github.com/brson/error-chain/blob/master/examples/quickstart.rs
+//! [quickstart.rs]: https://github.com/rust-lang-nursery/error-chain/blob/master/examples/quickstart.rs
 //! [intro]: http://brson.github.io/2016/11/30/starting-with-error-chain
 //!
 //! ## Why error chain?


### PR DESCRIPTION
This became quite a large sed. Most (but not all of the links are handled by github redirect but I waned to be on the safe side and future proof).

Please let me know if I should reduce the scope of the rename. at least the Travis related links need to be changed.

fixes https://github.com/rust-lang-nursery/error-chain/issues/204