### PR TITLE
Cache whether RUST_BACKTRACE is enabled in a relaxed atomic static.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
 - nightly
 # Oldest supported version for all features.
 # Use of https://github.com/rust-lang/rfcs/pull/16
-- 1.13.0
+- 1.14.0
 # Oldest supported version as dependency, with no features, tests, or examples.
 - 1.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [Add support for creating an error chain on boxed trait errors (`Box<Error>`)](https://github.com/rust-lang-nursery/error-chain/pull/156)
 - [Remove lint for unused doc comment.](https://github.com/rust-lang-nursery/error-chain/pull/199)
 - [Hide error_chain_processed macro from documentation.](https://github.com/rust-lang-nursery/error-chain/pull/212)
+- [Cache whether RUST_BACKTRACE is enabled in a relaxed atomic static.](https://github.com/rust-lang-nursery/error-chain/pull/210)
 
 # 0.10.0
 

--- a/src/bin/has_backtrace.rs
+++ b/src/bin/has_backtrace.rs
@@ -1,0 +1,17 @@
+//! Exits with exit code 0 if backtraces are disabled and 1 if they are enabled.
+//! Used by tests to make sure backtraces are available when they should be.
+
+#[macro_use]
+extern crate error_chain;
+
+error_chain! {
+    errors {
+        MyError
+    }
+}
+
+fn main() {
+    let err = Error::from(ErrorKind::MyError);
+    let has_backtrace = err.backtrace().is_some();
+    ::std::process::exit(has_backtrace as i32);
+}


### PR DESCRIPTION
Fixes #207. Inspired by [libfringe](https://github.com/edef1c/libfringe/blob/87452b58e0a4cbef4973e81419d719b0b8fc298b/src/stack/os/sys.rs#L63-L71) (thanks, @edef1c!).