### PR TITLE
Hide error_chain_processed macro from docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [Allow `chain_err` to be used on `Option<T>`](https://github.com/rust-lang-nursery/error-chain/pull/156)
 - [Add support for creating an error chain on boxed trait errors (`Box<Error>`)](https://github.com/rust-lang-nursery/error-chain/pull/156)
 - [Remove lint for unused doc comment.](https://github.com/rust-lang-nursery/error-chain/pull/199)
+- [Hide error_chain_processed macro from documentation.](https://github.com/rust-lang-nursery/error-chain/pull/212)
 
 # 0.10.0
 

--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -1,13 +1,13 @@
 /// Prefer to use `error_chain` instead of this macro.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! error_chain_processed {
+macro_rules! impl_error_chain_processed {
     // Default values for `types`.
     (
         types {}
         $( $rest: tt )*
     ) => {
-        error_chain_processed! {
+        impl_error_chain_processed! {
             types {
                 Error, ErrorKind, ResultExt, Result;
             }
@@ -22,7 +22,7 @@ macro_rules! error_chain_processed {
         }
         $( $rest: tt )*
     ) => {
-        error_chain_processed! {
+        impl_error_chain_processed! {
             types {
                 $error_name, $error_kind_name,
                 $result_ext_name;
@@ -392,7 +392,7 @@ macro_rules! error_chain_processing {
         }
     };
     ( ($a:tt, $b:tt, $c:tt, $d:tt) ) => {
-        error_chain_processed! {
+        impl_error_chain_processed! {
             types $a
             links $b
             foreign_links $c

--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -1,4 +1,5 @@
 /// Prefer to use `error_chain` instead of this macro.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! error_chain_processed {
     // Default values for `types`.
@@ -400,8 +401,7 @@ macro_rules! error_chain_processing {
     };
 }
 
-/// This macro is used for handling of duplicated and out-of-order fields. For
-/// the exact rules, see `error_chain_processed`.
+/// Macro for generating error types and traits. See crate level documentation for details.
 #[macro_export]
 macro_rules! error_chain {
     ( $( $block_name:ident { $( $block_content:tt )* } )* ) => {


### PR DESCRIPTION
Fixes #185 

Just hides the macro and updates documentation to not mention it.