### PR TITLE
Allow skipping the `Msg` variant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,10 @@
 //!             display("unknown toolchain version: '{}'", v), // trailing comma is allowed
 //!         }
 //!     }
+//!
+//!     // If this annotation is left off, a variant `Msg(s: String)` will be added, and `From`
+//!     // impls will be provided for `String` and `&str`
+//!     skip_msg_variant
 //! }
 //!
 //! # fn main() {}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -641,3 +641,24 @@ fn trailing_comma_in_errors_impl() {
         }
     };
 }
+
+#[test]
+fn skipping_msg_variant() {
+    error_chain! {
+        skip_msg_variant
+
+        errors {
+            MyMsg(s: String) {
+                description(&s)
+                display("{}", s)
+            }
+        }
+    }
+
+    let x = Error::from_kind(ErrorKind::MyMsg("some string".into()));
+    // This would fail to compile if we generate a `Msg` variant
+    match *x.kind() {
+        ErrorKind::MyMsg(_) => {}
+        ErrorKind::__Nonexhaustive {} => {}
+    }
+}


### PR DESCRIPTION
While the `Msg` variant may be a useful option for some users, many will
prefer to stick to more descriptive error types, and won't want this
variant present. This allows a `skip_msg_variant` flag to be passed to
`error_chain!`, which will cause no `Msg` variant to be present in the
generated code.

I've also refactored the body of `impl_error_chain_processing` to not
care about the number of arguments other than the final branch, so more
cases can be added in the future without having to touch as many places
as I did.

Fixes #200.