### PR TITLE
Use Void in __Nonexhaustive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ example_generated = []
 
 [dependencies]
 backtrace = { version = "0.3.3", optional = true }
+void = "1.0"

--- a/src/impl_error_chain_kind.rs
+++ b/src/impl_error_chain_kind.rs
@@ -177,7 +177,7 @@ macro_rules! impl_error_chain_kind {
             )*
 
             #[doc(hidden)]
-            __Nonexhaustive {}
+            __Nonexhaustive($crate::Void),
         }
     };
     // Unit variant

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,6 +536,8 @@
 //! [`map_err`]: https://doc.rust-lang.org/std/result/enum.Result.html#method.map_err
 //! [`BacktraceFrame`]: https://docs.rs/backtrace/0.3.2/backtrace/struct.BacktraceFrame.html
 
+extern crate void;
+
 use std::error;
 use std::iter::Iterator;
 use std::fmt;
@@ -649,6 +651,13 @@ impl<'a, T> fmt::Display for DisplayChain<'a, T>
         Ok(())
     }
 }
+
+/// Wrapper over void::Void, provided for 2 reasons:
+/// * Users shouldn't need to specify a void dependency in Cargo.toml to use error-chain
+/// * We can reuse whatever trait impls defined for void::Void
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[doc(hidden)]
+pub struct Void(::void::Void);
 
 /// Common state between errors.
 #[derive(Debug)]


### PR DESCRIPTION
This prevents construction of this variant.

Use a hidden public wrapper over `void::Void` for 2 reasons:
* Users shouldn't need to specify a `void` dependency in Cargo.toml to use `error-chain`.
* We can reuse whatever trait impls defined for `void::Void`.

Alternatively, `error-chain` can define its own `enum Void {}` to bring down amount of dependencies (as a rather fundamental crate, more dependencies can lead to issues, in my opinion).

Technically, this is a breaking change because `__Nonexhaustive` in 0.11.0 can still be used. If compatibility is a concern, `void` can be made an optional dependency and disabled by default - then 0.11.1 will only add a Cargo feature without breaking changes.