### PR TITLE
Fix new renamed_and_removed_lints warning

### DIFF
--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -179,7 +179,7 @@ macro_rules! impl_error_chain_processed {
                 self.description()
             }
 
-            #[allow(unknown_lints, unused_doc_comment, unused_doc_comment, unused_doc_comments)]
+            #[allow(unknown_lints, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
             fn cause(&self) -> Option<&::std::error::Error> {
                 match self.1.next_error {
                     Some(ref c) => Some(&**c),
@@ -421,7 +421,7 @@ macro_rules! impl_extract_backtrace {
     ($error_name: ident
      $error_kind_name: ident
      $([$link_error_path: path, $(#[$meta_links: meta])*])*) => {
-        #[allow(unknown_lints, unused_doc_comment, unused_doc_comments)]
+        #[allow(unknown_lints, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
         fn extract_backtrace(e: &(::std::error::Error + Send + 'static))
             -> Option<$crate::InternalBacktrace> {
             if let Some(e) = e.downcast_ref::<$error_name>() {

--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -179,7 +179,7 @@ macro_rules! impl_error_chain_processed {
                 self.description()
             }
 
-            #[allow(unknown_lints, unused_doc_comment)]
+            #[allow(unknown_lints, unused_doc_comments)]
             fn cause(&self) -> Option<&::std::error::Error> {
                 match self.1.next_error {
                     Some(ref c) => Some(&**c),
@@ -421,7 +421,7 @@ macro_rules! impl_extract_backtrace {
     ($error_name: ident
      $error_kind_name: ident
      $([$link_error_path: path, $(#[$meta_links: meta])*])*) => {
-        #[allow(unknown_lints, unused_doc_comment)]
+        #[allow(unknown_lints, unused_doc_comments)]
         fn extract_backtrace(e: &(::std::error::Error + Send + 'static))
             -> Option<$crate::InternalBacktrace> {
             if let Some(e) = e.downcast_ref::<$error_name>() {

--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -179,7 +179,7 @@ macro_rules! impl_error_chain_processed {
                 self.description()
             }
 
-            #[allow(unknown_lints, unused_doc_comments)]
+            #[allow(unknown_lints, unused_doc_comment, unused_doc_comment, unused_doc_comments)]
             fn cause(&self) -> Option<&::std::error::Error> {
                 match self.1.next_error {
                     Some(ref c) => Some(&**c),
@@ -421,7 +421,7 @@ macro_rules! impl_extract_backtrace {
     ($error_name: ident
      $error_kind_name: ident
      $([$link_error_path: path, $(#[$meta_links: meta])*])*) => {
-        #[allow(unknown_lints, unused_doc_comments)]
+        #[allow(unknown_lints, unused_doc_comment, unused_doc_comments)]
         fn extract_backtrace(e: &(::std::error::Error + Send + 'static))
             -> Option<$crate::InternalBacktrace> {
             if let Some(e) = e.downcast_ref::<$error_name>() {

--- a/src/impl_error_chain_kind.rs
+++ b/src/impl_error_chain_kind.rs
@@ -224,7 +224,7 @@ macro_rules! impl_error_chain_kind {
             $item:ident: $imode:tt [$(#[$imeta:meta])*] [$( $var:ident: $typ:ty ),*] {$( $funcs:tt )*}
         )*}
     ) => {
-        #[allow(unknown_lints, unused, unused_doc_comments)]
+        #[allow(unknown_lints, unused, unused_doc_comment, unused_doc_comments)]
         impl ::std::fmt::Display for $name {
             fn fmt(&self, fmt: &mut ::std::fmt::Formatter)
                 -> ::std::fmt::Result
@@ -247,7 +247,7 @@ macro_rules! impl_error_chain_kind {
                 }
             }
         }
-        #[allow(unknown_lints, unused, unused_doc_comments)]
+        #[allow(unknown_lints, unused, unused_doc_comment, unused_doc_comments)]
         impl $name {
             /// A string describing the error kind.
             pub fn description(&self) -> &str {

--- a/src/impl_error_chain_kind.rs
+++ b/src/impl_error_chain_kind.rs
@@ -224,7 +224,7 @@ macro_rules! impl_error_chain_kind {
             $item:ident: $imode:tt [$(#[$imeta:meta])*] [$( $var:ident: $typ:ty ),*] {$( $funcs:tt )*}
         )*}
     ) => {
-        #[allow(unknown_lints, unused, unused_doc_comment, unused_doc_comments)]
+        #[allow(unknown_lints, unused, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
         impl ::std::fmt::Display for $name {
             fn fmt(&self, fmt: &mut ::std::fmt::Formatter)
                 -> ::std::fmt::Result
@@ -247,7 +247,7 @@ macro_rules! impl_error_chain_kind {
                 }
             }
         }
-        #[allow(unknown_lints, unused, unused_doc_comment, unused_doc_comments)]
+        #[allow(unknown_lints, unused, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
         impl $name {
             /// A string describing the error kind.
             pub fn description(&self) -> &str {

--- a/src/impl_error_chain_kind.rs
+++ b/src/impl_error_chain_kind.rs
@@ -224,7 +224,7 @@ macro_rules! impl_error_chain_kind {
             $item:ident: $imode:tt [$(#[$imeta:meta])*] [$( $var:ident: $typ:ty ),*] {$( $funcs:tt )*}
         )*}
     ) => {
-        #[allow(unknown_lints, unused, unused_doc_comment)]
+        #[allow(unknown_lints, unused, unused_doc_comments)]
         impl ::std::fmt::Display for $name {
             fn fmt(&self, fmt: &mut ::std::fmt::Formatter)
                 -> ::std::fmt::Result
@@ -247,7 +247,7 @@ macro_rules! impl_error_chain_kind {
                 }
             }
         }
-        #[allow(unknown_lints, unused, unused_doc_comment)]
+        #[allow(unknown_lints, unused, unused_doc_comments)]
         impl $name {
             /// A string describing the error kind.
             pub fn description(&self) -> &str {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(missing_docs)]
-#![allow(unknown_lints)] // to be removed when unused_doc_comments lints is merged
 #![doc(html_root_url = "https://docs.rs/error-chain/0.11.0")]
 
 //! A library for consistent and reliable error handling


### PR DESCRIPTION
Builds on @hoodie's work in #246 to allow both `unused_doc_comment` and `unused_doc_comments` in a fully back-compatible fashion.

Fixes #245 