### PR TITLE
try to fix issue #251

### DIFF
--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -179,7 +179,8 @@ macro_rules! impl_error_chain_processed {
                 self.description()
             }
 
-            #[allow(unknown_lints, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
+            #[allow(unknown_lints, renamed_and_removed_lints)]
+            #[allow(unused_doc_comment, unused_doc_comments)]
             fn cause(&self) -> Option<&::std::error::Error> {
                 match self.1.next_error {
                     Some(ref c) => Some(&**c),
@@ -421,7 +422,8 @@ macro_rules! impl_extract_backtrace {
     ($error_name: ident
      $error_kind_name: ident
      $([$link_error_path: path, $(#[$meta_links: meta])*])*) => {
-        #[allow(unknown_lints, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
+        #[allow(unknown_lints, renamed_and_removed_lints)]
+        #[allow(unused_doc_comment, unused_doc_comments)]
         fn extract_backtrace(e: &(::std::error::Error + Send + 'static))
             -> Option<$crate::InternalBacktrace> {
             if let Some(e) = e.downcast_ref::<$error_name>() {

--- a/src/impl_error_chain_kind.rs
+++ b/src/impl_error_chain_kind.rs
@@ -224,7 +224,8 @@ macro_rules! impl_error_chain_kind {
             $item:ident: $imode:tt [$(#[$imeta:meta])*] [$( $var:ident: $typ:ty ),*] {$( $funcs:tt )*}
         )*}
     ) => {
-        #[allow(unknown_lints, unused, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
+        #[allow(unknown_lints, unused, renamed_and_removed_lints)]
+        #[allow(unused_doc_comment, unused_doc_comments)]
         impl ::std::fmt::Display for $name {
             fn fmt(&self, fmt: &mut ::std::fmt::Formatter)
                 -> ::std::fmt::Result
@@ -247,7 +248,8 @@ macro_rules! impl_error_chain_kind {
                 }
             }
         }
-        #[allow(unknown_lints, unused, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
+        #[allow(unknown_lints, unused, renamed_and_removed_lints)]
+        #[allow(unused_doc_comment, unused_doc_comments)]
         impl $name {
             /// A string describing the error kind.
             pub fn description(&self) -> &str {


### PR DESCRIPTION
I think that the following modification (seen in quick-error) could work here, to fix issue #251.
I splitted the problematic part in two parts:
1. ignore unknown/renamed/removed lints
2. disable warnings about unused doc comments
