### PR TITLE
Fix new macro import style

### DIFF
--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -1,6 +1,6 @@
 /// Prefer to use `error_chain` instead of this macro.
 #[doc(hidden)]
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! impl_error_chain_processed {
     // Default values for `types`.
     (
@@ -347,7 +347,7 @@ macro_rules! impl_error_chain_processed {
 
 /// Internal macro used for reordering of the fields.
 #[doc(hidden)]
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! error_chain_processing {
     (
         ({}, $b:tt, $c:tt, $d:tt)
@@ -400,7 +400,7 @@ macro_rules! error_chain_processing {
 }
 
 /// Macro for generating error types and traits. See crate level documentation for details.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! error_chain {
     ( $( $block_name:ident { $( $block_content:tt )* } )* ) => {
         error_chain_processing! {

--- a/src/impl_error_chain_kind.rs
+++ b/src/impl_error_chain_kind.rs
@@ -3,7 +3,20 @@
 //   - replace `impl Error` by `impl Item::description`
 //   - $imeta
 
+// Because of the `#[macro_export(local_inner_macros)]` usage on `impl_error_chain_kind` that macro
+// will only look inside this crate for macros to invoke. So using `stringify` or `write` from
+// the standard library will fail. Thus we here create simple wrappers for them that are not
+// exported as `local_inner_macros`, and thus they can in turn use the standard library macros.
 #[macro_export]
+macro_rules! stringify_internal {
+    ($($t:tt)*) => { stringify!($($t)*) }
+}
+#[macro_export]
+macro_rules! write_internal {
+    ($dst:expr, $($arg:tt)*) => (write!($dst, $($arg)*))
+}
+
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! impl_error_chain_kind {
     (   $(#[$meta:meta])*
@@ -272,18 +285,18 @@ macro_rules! impl_error_chain_kind {
         { display($self_:tt) -> ($( $exprs:tt )*) $( $tail:tt )*}
     ) => {
         |impl_error_chain_kind!(IDENT $self_): &$name, f: &mut ::std::fmt::Formatter| {
-            write!(f, $( $exprs )*)
+            write_internal!(f, $( $exprs )*)
         }
     };
     (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
         { display($pattern:expr) $( $tail:tt )*}
     ) => {
-        |_, f: &mut ::std::fmt::Formatter| { write!(f, $pattern) }
+        |_, f: &mut ::std::fmt::Formatter| { write_internal!(f, $pattern) }
     };
     (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
         { display($pattern:expr, $( $exprs:tt )*) $( $tail:tt )*}
     ) => {
-        |_, f: &mut ::std::fmt::Formatter| { write!(f, $pattern, $( $exprs )*) }
+        |_, f: &mut ::std::fmt::Formatter| { write_internal!(f, $pattern, $( $exprs )*) }
     };
     (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
         { $t:tt $( $tail:tt )*}
@@ -296,7 +309,7 @@ macro_rules! impl_error_chain_kind {
         { }
     ) => {
         |self_: &$name, f: &mut ::std::fmt::Formatter| {
-            write!(f, "{}", self_.description())
+            write_internal!(f, "{}", self_.description())
         }
     };
     (FIND_DESCRIPTION_IMPL $item:ident: $imode:tt $me:ident $fmt:ident
@@ -317,7 +330,7 @@ macro_rules! impl_error_chain_kind {
         [$( $var:ident ),*]
         { }
     ) => {
-        stringify!($item)
+        stringify_internal!($item)
     };
     (ITEM_BODY $(#[$imeta:meta])* $item:ident: UNIT
     ) => { };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -783,7 +783,7 @@ macro_rules! bail {
 /// ```
 ///
 /// See documentation for `bail!` macro for further details.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! ensure {
     ($cond:expr, $e:expr) => {
         if !($cond) {


### PR DESCRIPTION
Fixes #250 

Uses the same approach as described here to make macros usable in both the new and old way of importing them: https://users.rust-lang.org/t/2018-edition-macro-ergonomics/18790

Issue #250 has become more of a problem now when Rust 1.30 is out and the new way of importing macros is out on the stable channel. Would be really good to have this, or a variant of this, merged and a 0.12.1 patch release published.