### PR TITLE
Rust > 1.27.0 fix for dyn deprecation in nightly

### DIFF
--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -49,7 +49,7 @@ macro_rules! impl_error_chain_cause_or_source {
     ) => {
             #[allow(unknown_lints, renamed_and_removed_lints)]
             #[allow(unused_doc_comment, unused_doc_comments)]
-            fn source(&self) -> Option<&(std::error::Error + 'static)> {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
                 match self.1.next_error {
                     Some(ref c) => Some(&**c),
                     None => {
@@ -261,7 +261,7 @@ macro_rules! impl_error_chain_processed {
             }
 
             /// Construct a chained error from another boxed error and a kind, and generates a backtrace
-            pub fn with_boxed_chain<K>(error: Box<::std::error::Error + Send>, kind: K)
+            pub fn with_boxed_chain<K>(error: Box<dyn (::std::error::Error) + Send>, kind: K)
                 -> $error_name
                 where K: Into<$error_kind_name>
             {
@@ -524,7 +524,7 @@ macro_rules! impl_extract_backtrace {
      $([$link_error_path: path, $(#[$meta_links: meta])*])*) => {
         #[allow(unknown_lints, renamed_and_removed_lints)]
         #[allow(unused_doc_comment, unused_doc_comments)]
-        fn extract_backtrace(e: &(::std::error::Error + Send + 'static))
+        fn extract_backtrace(e: &(dyn (::std::error::Error) + Send + 'static))
             -> Option<$crate::InternalBacktrace> {
             if let Some(e) = e.downcast_ref::<$error_name>() {
                 return Some(e.1.backtrace.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,19 +559,19 @@ pub use backtrace::InternalBacktrace;
 
 #[derive(Debug)]
 /// Iterator over the error chain using the `Error::cause()` method.
-pub struct Iter<'a>(Option<&'a error::Error>);
+pub struct Iter<'a>(Option<&'a dyn error::Error>);
 
 impl<'a> Iter<'a> {
     /// Returns a new iterator over the error chain using `Error::cause()`.
-    pub fn new(err: Option<&'a error::Error>) -> Iter<'a> {
+    pub fn new(err: Option<&'a dyn error::Error>) -> Iter<'a> {
         Iter(err)
     }
 }
 
 impl<'a> Iterator for Iter<'a> {
-    type Item = &'a error::Error;
+    type Item = &'a dyn error::Error;
 
-    fn next<'b>(&'b mut self) -> Option<&'a error::Error> {
+    fn next<'b>(&'b mut self) -> Option<&'a dyn error::Error> {
         match self.0.take() {
             Some(e) => {
                 self.0 = match () {
@@ -631,7 +631,7 @@ pub trait ChainedError: error::Error + Send + 'static {
     /// Returns the first known backtrace, either from its State or from one
     /// of the errors from `foreign_links`.
     #[doc(hidden)]
-    fn extract_backtrace(e: &(error::Error + Send + 'static)) -> Option<InternalBacktrace>
+    fn extract_backtrace(e: &(dyn error::Error + Send + 'static)) -> Option<InternalBacktrace>
         where Self: Sized;
 }
 
@@ -663,7 +663,7 @@ impl<'a, T> fmt::Display for DisplayChain<'a, T>
 #[doc(hidden)]
 pub struct State {
     /// Next error in the error chain.
-    pub next_error: Option<Box<error::Error + Send>>,
+    pub next_error: Option<Box<dyn error::Error + Send>>,
     /// Backtrace for the current error.
     pub backtrace: InternalBacktrace,
 }
@@ -679,7 +679,7 @@ impl Default for State {
 
 impl State {
     /// Creates a new State type
-    pub fn new<CE: ChainedError>(e: Box<error::Error + Send>) -> State {
+    pub fn new<CE: ChainedError>(e: Box<dyn error::Error + Send>) -> State {
         let backtrace = CE::extract_backtrace(&*e)
             .unwrap_or_else(InternalBacktrace::new);
         State {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -378,7 +378,7 @@ mod foreign_link_test {
                    format!("{}", error_iter.next().unwrap()));
         assert_eq!(format!("{}", ForeignErrorCause {}),
                    format!("{}", error_iter.next().unwrap()));
-        assert_eq!(format!("{:?}", None as Option<&::std::error::Error>),
+        assert_eq!(format!("{:?}", None as Option<&dyn (::std::error::Error)>),
                    format!("{:?}", error_iter.next()));
     }
 


### PR DESCRIPTION
Added `dyn` qualifiers for trait objects  https://doc.rust-lang.org/edition-guide/rust-2018/trait-system/dyn-trait-for-trait-objects.html

I expect this to fail for < 1.27.0