### PR TITLE
Fix version issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ default = ["backtrace", "example_generated"]
 example_generated = []
 
 [dependencies]
-backtrace = { version = "0.3.3", optional = true }
+# https://github.com/rust-lang/backtrace-rs/commit/17db3f34b1e674b2a653f4a4399750e25f657eea in backtrace-rs 0.3.36
+# breaks 1.31.0 because of issues with "mod print"
+backtrace = { version = "0.3.3,<0.3.36", optional = true }
 
 [build-dependencies]
 version_check = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ example_generated = []
 # https://github.com/rust-lang/backtrace-rs/commit/17db3f34b1e674b2a653f4a4399750e25f657eea in backtrace-rs 0.3.36
 # breaks 1.31.0 because of issues with "mod print"
 backtrace = { version = "0.3.3,<0.3.36", optional = true }
+# For later rust try! compatibility
+try = "1.0"
 
 [build-dependencies]
 version_check = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -648,14 +648,14 @@ impl<'a, T> fmt::Display for DisplayChain<'a, T>
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         // Keep `try!` for 1.10 support
-        writeln!(fmt, "Error: {}", self.0)?;
+        try!(writeln!(fmt, "Error: {}", self.0));
 
         for e in self.0.iter().skip(1) {
-            writeln!(fmt, "Caused by: {}", e)?;
+            try!(writeln!(fmt, "Caused by: {}", e));
         }
 
         if let Some(backtrace) = ChainedError::backtrace(self.0) {
-            writeln!(fmt, "{:?}", backtrace)?;
+            try!(writeln!(fmt, "{:?}", backtrace));
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,6 +557,9 @@ pub use backtrace::Backtrace;
 #[doc(hidden)]
 pub use backtrace::InternalBacktrace;
 
+#[macro_use]
+extern crate try;
+
 #[derive(Debug)]
 #[allow(unknown_lints, bare_trait_objects)]
 /// Iterator over the error chain using the `Error::cause()` method.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -654,7 +654,7 @@ impl<'a, T> fmt::Display for DisplayChain<'a, T>
             writeln!(fmt, "Caused by: {}", e)?;
         }
 
-        if let Some(backtrace) = self.0.backtrace() {
+        if let Some(backtrace) = ChainedError::backtrace(self.0) {
             writeln!(fmt, "{:?}", backtrace)?;
         }
 


### PR DESCRIPTION
This should fix both #270 and #274 as well as an issue I noted with particular versions of backtrace-rs and Rust 1.31.0