### PR TITLE
Resolve failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
 # Oldest supported version for all features.
 # Use of https://github.com/rust-lang/rfcs/pull/16
 # rustc-demangle uses feature `rename-dependency`
-- 1.31.0
+- 1.32.0
 # Oldest supported version as dependency, with no features, tests, or examples.
 - 1.13.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rust:
 # rustc-demangle uses feature `rename-dependency`
 - 1.31.0
 # Oldest supported version as dependency, with no features, tests, or examples.
-- 1.10.0
+- 1.13.0
 
 sudo: false
 cache: cargo
@@ -26,7 +26,7 @@ before_script:
 
 script:
 - travis-cargo build -- $FEATURES
-- travis-cargo --skip 1.10.0 test -- $FEATURES
+- travis-cargo --skip 1.13.0 test -- $FEATURES
 
 after_success:
 - travis-cargo --only stable doc
@@ -44,4 +44,4 @@ env:
 matrix:
   exclude:
   - env: FEATURES=--features=backtrace
-    rust: 1.10.0
+    rust: 1.13.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -647,14 +647,13 @@ impl<'a, T> fmt::Display for DisplayChain<'a, T>
     where T: ChainedError
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        // Keep `try!` for 1.10 support
         writeln!(fmt, "Error: {}", self.0)?;
 
         for e in self.0.iter().skip(1) {
             writeln!(fmt, "Caused by: {}", e)?;
         }
 
-        if let Some(backtrace) = self.0.backtrace() {
+        if let Some(backtrace) = ChainedError::backtrace(self.0) {
             writeln!(fmt, "{:?}", backtrace)?;
         }
 


### PR DESCRIPTION
Minimum supported rust is now 1.13.0 (without backtrace support)
Minimum supported rust is now 1.32 with backtrace support (see backtrace-rs)
Explicitly call ChainedError::backtrace()