### PR TITLE
Fix backtrace with 1.31.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ default = ["backtrace", "example_generated"]
 example_generated = []
 
 [dependencies]
-backtrace = { version = "0.3.3", optional = true }
+# https://github.com/rust-lang/backtrace-rs/commit/17db3f34b1e674b2a653f4a4399750e25f657eea in backtrace-rs 0.3.36
+# breaks 1.31.0 because of issues with "mod print"
+backtrace = { version = "0.3.3,<0.3.36", optional = true }
 
 [build-dependencies]
 version_check = "0.9"


### PR DESCRIPTION
Backtrace 0.3.36+ breaks Rust 1.31.0 because of https://github.com/rust-lang/backtrace-rs/commit/17db3f34b1e674b2a653f4a4399750e25f657eea