### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rust:
 # rustc-demangle uses feature `rename-dependency`
 - 1.32.0
 # Oldest supported version as dependency, with no features, tests, or examples.
-- 1.13.0
+- 1.27.0
 
 sudo: false
 cache: cargo
@@ -44,4 +44,4 @@ env:
 matrix:
   exclude:
   - env: FEATURES=--features=backtrace
-    rust: 1.13.0
+    rust: 1.27.0

--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -301,10 +301,6 @@ macro_rules! impl_error_chain_processed {
         }
 
         impl ::std::error::Error for $error_name {
-            fn description(&self) -> &str {
-                self.description()
-            }
-
             impl_error_chain_cause_or_source!{
                 types {
                     $error_kind_name
@@ -369,7 +365,7 @@ macro_rules! impl_error_chain_processed {
                 $(
                     $(#[$meta_foreign_links])*
                     $foreign_link_variant(err: $foreign_link_error_path) {
-                        description(::std::error::Error::description(err))
+                        description("")
                         display("{}", err)
                     }
                 ) *


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes an implementation of `description` in `impl ::std::error::Error`
- Cleanups description from `foreign_link_variant`
- Increases minimal version to 1.27.0 in travis

Related PR: https://github.com/rust-lang/rust/pull/66919