### PR TITLE
Allow deprecated Error::description

### DIFF
--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -301,6 +301,7 @@ macro_rules! impl_error_chain_processed {
         }
 
         impl ::std::error::Error for $error_name {
+            #[allow(deprecated)]
             fn description(&self) -> &str {
                 self.description()
             }
@@ -356,6 +357,7 @@ macro_rules! impl_error_chain_processed {
 
         impl_error_chain_kind! {
             /// The kind of an error.
+            #[allow(deprecated)]
             #[derive(Debug)]
             pub enum $error_kind_name {
                 $(
@@ -369,6 +371,7 @@ macro_rules! impl_error_chain_processed {
                 $(
                     $(#[$meta_foreign_links])*
                     $foreign_link_variant(err: $foreign_link_error_path) {
+			#[allow(deprecated)]
                         description(::std::error::Error::description(err))
                         display("{}", err)
                     }


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Allows `description` in `impl ::std::error::Error`

Related PR: https://github.com/rust-lang/rust/pull/66919
Alternative PR(with removed `description`): https://github.com/rust-lang-nursery/error-chain/pull/283