### PR TITLE
Use Error::description only for rust below 1.42

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,10 @@ fn main() {
         println!("cargo:rustc-cfg=has_error_source");
     }
 
+    if is_min_version("1.42").unwrap_or(false) {
+        println!("cargo:rustc-cfg=has_error_description_deprecated");
+    }
+
     // So we can get the build profile for has_backtrace_depending_on_env test
     if let Ok(profile) = env::var("PROFILE") {
         println!("cargo:rustc-cfg=build={:?}", profile);

--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -68,6 +68,21 @@ macro_rules! impl_error_chain_cause_or_source {
         };
 }
 
+/// Conditional usage of deprecated Error::description
+#[doc(hidden)]
+#[cfg(has_error_description_deprecated)]
+#[macro_export(local_inner_macros)]
+macro_rules! call_to_deprecated_description {
+    ($e:ident) => { "" };
+}
+
+#[doc(hidden)]
+#[cfg(not(has_error_description_deprecated))]
+#[macro_export(local_inner_macros)]
+macro_rules! call_to_deprecated_description {
+    ($e:ident) => { ::std::error::Error::description($e) };
+}
+
 /// Prefer to use `error_chain` instead of this macro.
 #[doc(hidden)]
 #[macro_export(local_inner_macros)]
@@ -301,6 +316,7 @@ macro_rules! impl_error_chain_processed {
         }
 
         impl ::std::error::Error for $error_name {
+            #[cfg(not(has_error_description_deprecated))]
             fn description(&self) -> &str {
                 self.description()
             }
@@ -369,7 +385,7 @@ macro_rules! impl_error_chain_processed {
                 $(
                     $(#[$meta_foreign_links])*
                     $foreign_link_variant(err: $foreign_link_error_path) {
-                        description(::std::error::Error::description(err))
+                        description(call_to_deprecated_description!(err))
                         display("{}", err)
                     }
                 ) *


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon (1.42)

This PR:
- adds configuration options: `has_error_description_deprecated`
- implements Error::description conditionally
- create a conditional macro `impl_error_chain_kind` without  usage of `Error::description`

Related PR: https://github.com/rust-lang/rust/pull/66919
Alternative PR(with removed description): https://github.com/rust-lang-nursery/error-chain/pull/283